### PR TITLE
Modified artifactory username to use a secret

### DIFF
--- a/.github/workflows/sign-chart.yml
+++ b/.github/workflows/sign-chart.yml
@@ -27,10 +27,6 @@ on:
         required: false
         default: https://niartifacts.jfrog.io/artifactory/rds-hlm
         type: string
-      repository_user:
-        description: The user to connect to the helm repository
-        required: true
-        type: string
       version:
         description: Version of the helm chart to sign
         required: true
@@ -38,6 +34,9 @@ on:
     secrets:
       GPG_PRIVATE_KEY:
         description: Base 64 encoded gpg private key to use for signing
+        required: true
+      REPOSITORY_USERNAME:
+        description: The username to connect to the helm repository
         required: true
       REPOSITORY_PASSWORD:
         description: The password to connect to the helm repository
@@ -48,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sign into helm
-        run: helm repo add ${{ inputs.repository_name }} ${{ inputs.repository_url }} --username ${{ inputs.repository_user }} --password ${{ secrets.REPOSITORY_PASSWORD }}
+        run: helm repo add ${{ inputs.repository_name }} ${{ inputs.repository_url }} --username ${{ secrets.REPOSITORY_USERNAME }} --password ${{ secrets.REPOSITORY_PASSWORD }}
       - name: Update helm repo
         run: helm repo update
       - name: Download chart

--- a/.github/workflows/sign-container.yml
+++ b/.github/workflows/sign-container.yml
@@ -17,10 +17,6 @@ on:
         required: false
         default: niartifacts.jfrog.io
         type: string
-      registry_username:
-        description: User to connect to artifactory
-        required: true
-        type: string
       signature_store_bucket:
         description: AWS S3 bucket to hold signatures
         required: true
@@ -40,6 +36,9 @@ on:
       GPG_PRIVATE_KEY:
         description: Base 64 encoded gpg private key to use for signing
         required: true
+      REGISTRY_USERNAME:
+        description: Username to use to pull from container registry
+        required: true
       REGISTRY_PASSWORD:
         description: Password or token to use to pull from container registry
         required: true
@@ -51,7 +50,7 @@ jobs:
       - name: Log into registry
         uses: redhat-actions/podman-login@v1
         with:
-          username: ${{ inputs.registry_username }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
           registry: ${{ inputs.registry }}
       - name: Create signature staging directory


### PR DESCRIPTION
### What does this Pull Request accomplish?

Our GitHub pipelines use secrets for the Artifactory username and password. I updated the signing workflows to allow the usage of secrets for the username.

### Why should this Pull Request be merged?

Need this to change to support Docker image and Helm chart signing.

### What testing has been done?

None - need to use in final pipeline to ensure the issue is addressed.
