### PR TITLE
Added the package and publish Helm chart workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @irwand @neilvana
+.github/workflows/package-and-publish-helm-chart.yml @lnowotny @BKnight760
+bin/package-and-publish-helm-chart.py @lnowotny @BKnight760

--- a/.github/workflows/package-and-publish-helm-chart.yml
+++ b/.github/workflows/package-and-publish-helm-chart.yml
@@ -46,6 +46,10 @@ jobs:
       run: helm dependency build ${{ inputs.helm_chart_directory }}
     - name: Lint Helm chart
       run: helm lint ${{ inputs.helm_chart_directory }}
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install packaging
     - name: Package and publish Helm chart
       id: package_helm_chart_step
       run: python bin/package-and-publish-helm-chart.py 

--- a/.github/workflows/package-and-publish-helm-chart.yml
+++ b/.github/workflows/package-and-publish-helm-chart.yml
@@ -1,0 +1,63 @@
+name: Package and Publish Helm chart
+
+on:
+  workflow_call:
+    inputs:
+      helm_chart_directory:
+        required: true
+        type: string
+      helm_package_build_artifact_name:
+        required: true
+        type: string
+    outputs:
+      helm_package_filename:
+        description: "The filename of the packaged Helm chart"
+        value: ${{ jobs.package_and_publish_helm_chart_job.outputs.helm_package_filename }}
+      helm_package_major_version:
+        description: "The major version of the packaged Helm chart"
+        value: ${{ jobs.package_and_publish_helm_chart_job.outputs.helm_package_major_version }}
+      helm_package_minor_version:
+        description: "The minor version of the packaged Helm chart"
+        value: ${{ jobs.package_and_publish_helm_chart_job.outputs.helm_package_minor_version }}
+      helm_package_version:
+        description: "The version of the packaged Helm chart"
+        value: ${{ jobs.package_and_publish_helm_chart_job.outputs.helm_package_version }}
+    secrets:
+      artifactory_user:
+        required: true
+      artifactory_token:
+        required: true
+
+jobs:
+  package_and_publish_helm_chart_job:
+    name: Package and Publish Helm chart
+    runs-on: ubuntu-latest
+    env:
+      ARTIFACTORY_USER: ${{ secrets.artifactory_user }}
+      ARTIFACTORY_TOKEN: ${{ secrets.artifactory_token }}
+    outputs:
+      helm_package_filename: ${{ steps.package_helm_chart_step.outputs.helm_package_filename }}
+      helm_package_version: ${{ steps.package_helm_chart_step.outputs.helm_package_version }}
+      helm_package_major_version: ${{ steps.package_helm_chart_step.outputs.helm_package_major_version }}
+      helm_package_minor_version: ${{ steps.package_helm_chart_step.outputs.helm_package_minor_version }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download helm dependencies
+      run: helm dependency build ${{ inputs.helm_chart_directory }}
+    - name: Lint Helm chart
+      run: helm lint ${{ inputs.helm_chart_directory }}
+    - name: Package and publish Helm chart
+      id: package_helm_chart_step
+      run: python bin/package-and-publish-helm-chart.py 
+                  ${{ inputs.helm_chart_directory }}
+                  ${{ runner.temp }}
+                  ${{ github.run_number}}.${{ github.run_attempt}}
+                  ${{ github.ref != 'refs/heads/master' }}
+                  ${{ github.sha }}.${{ github.run_attempt }}
+    - name: Upload build artifact - ${{ inputs.helm_package_build_artifact_name }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.helm_package_build_artifact_name }}
+        path: ${{ steps.package_helm_chart_step.outputs.helm_package_filepath }}
+        if-no-files-found: error
+    

--- a/bin/package-and-publish-helm-chart.py
+++ b/bin/package-and-publish-helm-chart.py
@@ -1,0 +1,148 @@
+import os
+import re
+import requests
+import subprocess
+import sys
+
+from shutil import copyfile
+
+
+def main():
+  args = sys.argv[1:]
+  chart_path = args[0]
+  working_directory = args[1]
+  build_number = args[2]
+  is_prerelease = args[3]
+  application_version = args[4]
+
+  chart_filename = chart_path + '/Chart.yaml'
+
+  print(f'build_number = {build_number}')
+  print(f'is_prerelease = {is_prerelease}')
+  print(f'application_version = {application_version}')
+
+  username = os.getenv('ARTIFACTORY_USER')
+  token = os.getenv('ARTIFACTORY_TOKEN')
+
+  # Parse chart name from the Chart.yaml
+  chart_name = None
+  with open(chart_filename) as file:
+    for line in file:
+      if line.startswith('name:'):
+        chart_name = line.split(':')[1].strip()
+        print(f'Chart name: {chart_name}')
+        break
+
+  # Parse version from the Chart.yaml
+  chart_version = '0.0.0'
+  with open(chart_filename) as file:
+    for line in file:
+      if line.startswith('version:'):
+        chart_version = line.split(':')[1].strip()
+        print(f'Chart version: {chart_version}')
+        break
+
+  version_elements = chart_version.split('.')
+  version_major = int(version_elements[0])
+  version_minor = int(version_elements[1])
+  version_patch = int(version_elements[2])
+
+  # Retrieve the list of published helm chart versions from Artifactory
+  auth = (username, token)
+  response = requests.get(
+    url=f'https://niartifacts.jfrog.io/artifactory/rnd-helm-ci/ni/systemlink/{chart_name}/{version_major}/{version_minor}',
+    auth=auth)
+
+  # Find the highest version of the chart on Artifactory
+  highest_version = [version_major, version_minor, version_patch]
+  if response.status_code == 200:
+    print('Found existing charts on the repo...')
+    # Parse HTTP response
+    for line in response.text.splitlines():
+      if line.startswith('<a href='):
+        start = line.find('">') + len('">')
+        end = line.find('</a>')
+        package_name = line[start:end]
+        print(f'Package name: {package_name}')
+         # We need to parse the following:
+        #  chartname-0.1.27.tgz
+        #  chartname-0.1.27.tgz.prov
+        #  chartname-0.1.27-pre.20220629.4.tgz
+        pattern = r"(.+)-(\d+\.\d+\.\d+)(-pre\.\d+\.\d+)?\.tgz\S*$"
+        result = re.match(pattern, package_name)
+        groups = result.groups()
+
+        package_version = groups[1]
+        print(f'Package version: {package_version}')
+        package_version_elements = package_version.split('.')
+        package_major = int(package_version_elements[0])
+        package_minor = int(package_version_elements[1])
+        package_patch = int(package_version_elements[2])
+
+        if ((package_major >= highest_version[0]) and (package_minor >= highest_version[1]) and (package_patch > highest_version[2])):
+          highest_version = [package_major, package_minor, package_patch]
+  elif (response.status_code == 404):
+    print('No charts for this major.minor version exist.  Using current chart version.')
+  else:
+    print(response.text)
+    sys.exit(1)
+
+  print(f'Highest version: {highest_version}')
+
+  # Increment the helm chart version
+  package_major_version = highest_version[0]
+  package_minor_version = highest_version[1]
+  package_patch_version = highest_version[2]
+
+  if is_prerelease == 'true':
+    updated_version_string = f'{package_major_version}.{package_minor_version}.{package_patch_version}-pre.{build_number}'
+  else:
+    updated_version_string = f'{package_major_version}.{package_minor_version}.{package_patch_version + 1}'
+
+  print(f'Updated version: {updated_version_string}')
+  
+  # Package the helm chart using the newly incremented version
+  # It's important to format command as a string here, as this is required for using shell=True on Linux.
+  command = f'helm package {chart_path} --version {updated_version_string} --app-version {application_version} --destination {working_directory}'
+  proc = subprocess.run(command, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  if proc.returncode != 0:
+    print(f'process return code = {str(proc.returncode)}')
+    print(f'stdout = {proc.stdout}')
+    print(f'stderr = {proc.stderr}')
+    exit(proc.returncode)
+
+  helm_package_filename = f'{chart_name}-{updated_version_string}.tgz'
+  helm_package_filepath = os.path.join(working_directory, helm_package_filename)
+
+  print(f'::set-output name=helm_package_filename::{helm_package_filename}')
+  print(f'::set-output name=helm_package_filepath::{helm_package_filepath}')
+  print(f'::set-output name=helm_package_version::{updated_version_string}')
+  print(f'::set-output name=helm_package_major_version::{package_major_version}')
+  print(f'::set-output name=helm_package_minor_version::{package_minor_version}')
+
+  print(f'helm_package_filename = {helm_package_filename}')
+  print(f'helm_package_filepath = {helm_package_filepath}')
+  print(f'helm_package_version = {updated_version_string}')
+  print(f'helm_package_major_version = {package_major_version}')
+  print(f'helm_package_minor_version = {package_minor_version}')
+
+  # Publish the Helm chart package
+  with open(helm_package_filepath, 'rb') as f:
+    data = f.read()
+    auth = (username, token)
+    response = requests.put(
+      url='https://niartifacts.jfrog.io/artifactory/rnd-helm-ci/ni/systemlink/{chart_name}/{package_major}/{package_minor}/{helm_package}'.format(
+        chart_name=chart_name,
+        package_major=package_major_version,
+        package_minor=package_minor_version,
+        helm_package=helm_package_filename),
+      data=data,
+      auth=auth)
+  print(response)
+
+  if response.status_code != 201:
+    print(response.text)
+    sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/bin/package-and-publish-helm-chart.py
+++ b/bin/package-and-publish-helm-chart.py
@@ -4,57 +4,54 @@ import requests
 import subprocess
 import sys
 
+from packaging.version import Version
 from shutil import copyfile
+
+
+def get_chart_attribute(chart_filepath, attribute_name, default_value):
+  with open(chart_filepath) as file:
+    for line in file:
+      if line.startswith(f'{attribute_name}:'):
+        return line.split(':')[1].strip()
+  return default_value
 
 
 def main():
   args = sys.argv[1:]
-  chart_path = args[0]
+  chart_directory = args[0]
   working_directory = args[1]
   build_number = args[2]
-  is_prerelease = args[3]
+  is_prerelease = args[3] == 'true'
   application_version = args[4]
 
-  chart_filename = chart_path + '/Chart.yaml'
+  chart_filepath = chart_directory + '/Chart.yaml'
 
   print(f'build_number = {build_number}')
   print(f'is_prerelease = {is_prerelease}')
   print(f'application_version = {application_version}')
 
   username = os.getenv('ARTIFACTORY_USER')
-  token = os.getenv('ARTIFACTORY_TOKEN')
+  token = os.getenv('ARTIFACTORY_PASSWORD')
 
-  # Parse chart name from the Chart.yaml
-  chart_name = None
-  with open(chart_filename) as file:
-    for line in file:
-      if line.startswith('name:'):
-        chart_name = line.split(':')[1].strip()
-        print(f'Chart name: {chart_name}')
-        break
+  # Parse chart name from the Chart.yaml file
+  chart_name = get_chart_attribute(chart_filepath, 'name', None)
+  print(f'Chart name: {chart_name}')
 
-  # Parse version from the Chart.yaml
-  chart_version = '0.0.0'
-  with open(chart_filename) as file:
-    for line in file:
-      if line.startswith('version:'):
-        chart_version = line.split(':')[1].strip()
-        print(f'Chart version: {chart_version}')
-        break
+  # Parse chart version from the Chart.yaml file
+  chart_version_string = get_chart_attribute(chart_filepath, 'version', '0.0.0')
+  print(f'Chart version: {chart_version_string}')
 
-  version_elements = chart_version.split('.')
-  version_major = int(version_elements[0])
-  version_minor = int(version_elements[1])
-  version_patch = int(version_elements[2])
+  chart_version = Version(chart_version_string)
+  version_major = chart_version.major
+  version_minor = chart_version.minor
 
   # Retrieve the list of published helm chart versions from Artifactory
-  auth = (username, token)
   response = requests.get(
     url=f'https://niartifacts.jfrog.io/artifactory/rnd-helm-ci/ni/systemlink/{chart_name}/{version_major}/{version_minor}',
-    auth=auth)
+    auth=(username, token))
 
   # Find the highest version of the chart on Artifactory
-  highest_version = [version_major, version_minor, version_patch]
+  highest_version = chart_version
   if response.status_code == 200:
     print('Found existing charts on the repo...')
     # Parse HTTP response
@@ -64,7 +61,7 @@ def main():
         end = line.find('</a>')
         package_name = line[start:end]
         print(f'Package name: {package_name}')
-         # We need to parse the following:
+        # We need to parse the following:
         #  chartname-0.1.27.tgz
         #  chartname-0.1.27.tgz.prov
         #  chartname-0.1.27-pre.20220629.4.tgz
@@ -72,15 +69,13 @@ def main():
         result = re.match(pattern, package_name)
         groups = result.groups()
 
+        # package_vesrion does not include prelease portion of version
         package_version = groups[1]
         print(f'Package version: {package_version}')
-        package_version_elements = package_version.split('.')
-        package_major = int(package_version_elements[0])
-        package_minor = int(package_version_elements[1])
-        package_patch = int(package_version_elements[2])
 
-        if ((package_major >= highest_version[0]) and (package_minor >= highest_version[1]) and (package_patch > highest_version[2])):
-          highest_version = [package_major, package_minor, package_patch]
+        current_version = Version(package_version)
+        if current_version > highest_version:
+          highest_version = current_version
   elif (response.status_code == 404):
     print('No charts for this major.minor version exist.  Using current chart version.')
   else:
@@ -89,21 +84,20 @@ def main():
 
   print(f'Highest version: {highest_version}')
 
-  # Increment the helm chart version
-  package_major_version = highest_version[0]
-  package_minor_version = highest_version[1]
-  package_patch_version = highest_version[2]
+  # Increment the Helm chart version for committed builds
+  package_major_version = highest_version.major
+  package_minor_version = highest_version.minor
 
-  if is_prerelease == 'true':
-    updated_version_string = f'{package_major_version}.{package_minor_version}.{package_patch_version}-pre.{build_number}'
+  if is_prerelease:
+    updated_version_string = f'{highest_version}-pre.{build_number}'
   else:
-    updated_version_string = f'{package_major_version}.{package_minor_version}.{package_patch_version + 1}'
+    updated_version_string = f'{package_major_version}.{package_minor_version}.{highest_version.micro + 1}'
 
   print(f'Updated version: {updated_version_string}')
-  
-  # Package the helm chart using the newly incremented version
+
+  # Package the Helm chart using the newly incremented version
   # It's important to format command as a string here, as this is required for using shell=True on Linux.
-  command = f'helm package {chart_path} --version {updated_version_string} --app-version {application_version} --destination {working_directory}'
+  command = f'helm package {chart_directory} --version {updated_version_string} --app-version {application_version} --destination {working_directory}'
   proc = subprocess.run(command, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   if proc.returncode != 0:
     print(f'process return code = {str(proc.returncode)}')
@@ -129,7 +123,7 @@ def main():
   # Publish the Helm chart package
   with open(helm_package_filepath, 'rb') as f:
     data = f.read()
-    auth = (username, token)
+    auth = (username, password)
     response = requests.put(
       url='https://niartifacts.jfrog.io/artifactory/rnd-helm-ci/ni/systemlink/{chart_name}/{package_major}/{package_minor}/{helm_package}'.format(
         chart_name=chart_name,

--- a/bin/package-and-publish-helm-chart.py
+++ b/bin/package-and-publish-helm-chart.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 
 from packaging.version import Version
-from shutil import copyfile
 
 
 def get_chart_attribute(chart_filepath, attribute_name, default_value):


### PR DESCRIPTION
### What does this Pull Request accomplish?

SystemLink has many services in GitHub repos that would like to share certain parts of the build process. This PR introduces a reusable workflow for the packaging and publishing of Helm charts.

### Why should this Pull Request be merged?

The new workflow is needed to reduce duplicated logic in our build workflows.

### What testing has been done?

I updated a helium service to use this workflow (locally within the repo) and the workflow succeeded:
https://github.com/ni-kismet/helium-security-ui/actions/runs/2761645106
