### PR TITLE
Consider main branch as release vs prerelease

### DIFF
--- a/.github/workflows/package-and-publish-helm-chart.yml
+++ b/.github/workflows/package-and-publish-helm-chart.yml
@@ -63,7 +63,7 @@ jobs:
                   ${{ inputs.helm_chart_directory }}
                   ${{ runner.temp }}
                   ${{ github.run_number}}.${{ github.run_attempt}}
-                  ${{ github.ref != 'refs/heads/master' }}
+                  ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
                   ${{ github.sha }}.${{ github.run_attempt }}
     - name: Upload build artifact - ${{ inputs.helm_package_build_artifact_name }}
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
### What does this Pull Request accomplish?

`main` is now considered an official branch in addition to `master`.

### Why should this Pull Request be merged?

By default new GitHub and AzureDevOps repos use `main` as the default branch.  Repos exist which use both conventions.

### What testing has been done?

None, just visual inspection.
